### PR TITLE
fix duration calculation bug when longer than 1 day

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ export OC_TOKEN="sha256~xxx"
 Login to the **hub** cluster, gather the metrics to folder `$PWD/$MANAGED_CLUSTER_NAME`.
 
 ```bash
-export DURATION=$(oc get managedclusters $MANAGED_CLUSTER_NAME --no-headers | awk '{gsub(/h/,"",$6); $6+=1; print $6"h"}')
+export DURATION=$(oc get managedclusters $MANAGED_CLUSTER_NAME --no-headers | awk '{gsub(/h/,"",$6); if ($6 ~ /d/) { split($6, arr, "d"); $6=(arr[1]*24)+arr[2]; } $6+=1; print $6"h"}')
 mkdir $MANAGED_CLUSTER_NAME
 docker run -e OC_CLUSTER_URL=$OC_CLUSTER_URL -e OC_TOKEN=$OC_TOKEN -e DURATION=$DURATION -e CLUSTER=spoke -v $PWD/$MANAGED_CLUSTER_NAME:/acm-inspector/output quay.io/haoqing/acm-inspector:latest > $PWD/$MANAGED_CLUSTER_NAME/logs
 ```


### PR DESCRIPTION
```
$ echo "cluster1        true           https://api.server-foundation-sno-p8fbq.dev04.red-chesterfield.com:6443   True     True        1d17h"| awk '{gsub(/h/,"",$6); if ($6 ~ /d/) { split($6, arr, "d"); $6=(arr[1]*24)+arr[2]; } $6+=1; print $6"h"}'
42h
$ echo "cluster1        true           https://api.server-foundation-sno-p8fbq.dev04.red-chesterfield.com:6443   True     True        1d2h"| awk '{gsub(/h/,"",$6); if ($6 ~ /d/) { split($6, arr, "d"); $6=(arr[1]*24)+arr[2]; } $6+=1; print $6"h"}'
27h
$ echo "cluster1        true           https://api.server-foundation-sno-p8fbq.dev04.red-chesterfield.com:6443   True     True        2h"| awk '{gsub(/h/,"",$6); if ($6 ~ /d/) { split($6, arr, "d"); $6=(arr[1]*24)+arr[2]; } $6+=1; print $6"h"}'
3h
```